### PR TITLE
feat(solver): Confirm Win + New Game defaults

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -388,7 +388,7 @@ class _GridSection extends StatelessWidget {
                     child: ElevatedButton.icon(
                       onPressed: state.isLoading
                           ? null
-                          : () {
+                          : () async {
                               // Confirm only if last row has a complete word
                               if (state.grid.isEmpty ||
                                   state.grid.last.isEmpty) {
@@ -402,6 +402,21 @@ class _GridSection extends StatelessWidget {
                                   const SnackBar(
                                     content: Text(
                                       'Enter a complete word to confirm win',
+                                    ),
+                                    duration: Duration(milliseconds: 1500),
+                                  ),
+                                );
+                                return;
+                              }
+                              // Validate against previous feedback/constraints
+                              final ok = await controller
+                                  .canConfirmWinWithCurrentRowWord();
+                              if (!context.mounted) return;
+                              if (!ok) {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(
+                                    content: Text(
+                                      'Word conflicts with previous feedback',
                                     ),
                                     duration: Duration(milliseconds: 1500),
                                   ),

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -383,32 +383,54 @@ class _GridSection extends StatelessWidget {
               Row(
                 mainAxisAlignment: MainAxisAlignment.end,
                 children: [
-                  if ((state.lastResponse?.recommendations.length ?? 0) == 1)
-                    Padding(
-                      padding: const EdgeInsets.only(right: 8.0),
-                      child: ElevatedButton.icon(
+                  Padding(
+                    padding: const EdgeInsets.only(right: 8.0),
+                    child: ElevatedButton.icon(
+                      onPressed: state.isLoading
+                          ? null
+                          : () {
+                              // Confirm only if last row has a complete word
+                              if (state.grid.isEmpty ||
+                                  state.grid.last.isEmpty) {
+                                return;
+                              }
+                              final isComplete = !state.grid.last.any(
+                                (t) => t.letter.isEmpty,
+                              );
+                              if (!isComplete) {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(
+                                    content: Text(
+                                      'Enter a complete word to confirm win',
+                                    ),
+                                    duration: Duration(milliseconds: 1500),
+                                  ),
+                                );
+                                return;
+                              }
+                              controller.confirmWin();
+                            },
+                      icon: const Icon(Icons.check_circle),
+                      label: const Text('Confirm win'),
+                    ),
+                  ),
+                  Consumer(
+                    builder: (context, ref, _) {
+                      final fillerCtrl = ref.read(
+                        fillerControllerProvider.notifier,
+                      );
+                      return ElevatedButton.icon(
                         onPressed: state.isLoading
                             ? null
                             : () {
-                                final single =
-                                    state.lastResponse!.recommendations.first;
-                                // If current row incomplete, fill with word before confirming
-                                final isComplete = !state.grid.last.any(
-                                  (t) => t.letter.isEmpty,
-                                );
-                                if (!isComplete) {
-                                  controller.applyWordToCurrentRow(single.word);
-                                }
-                                controller.confirmWin(single.word);
+                                controller.resetGame();
+                                // Clear filler query to reset the filler words list/UI
+                                fillerCtrl.setQuery('', config: state.config);
                               },
-                        icon: const Icon(Icons.check_circle),
-                        label: const Text('Confirm win'),
-                      ),
-                    ),
-                  ElevatedButton.icon(
-                    onPressed: state.isLoading ? null : controller.resetGame,
-                    icon: const Icon(Icons.refresh),
-                    label: const Text('New Game'),
+                        icon: const Icon(Icons.refresh),
+                        label: const Text('New Game'),
+                      );
+                    },
                   ),
                   const SizedBox(width: 8),
                   Consumer(

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -383,6 +383,28 @@ class _GridSection extends StatelessWidget {
               Row(
                 mainAxisAlignment: MainAxisAlignment.end,
                 children: [
+                  if ((state.lastResponse?.recommendations.length ?? 0) == 1)
+                    Padding(
+                      padding: const EdgeInsets.only(right: 8.0),
+                      child: ElevatedButton.icon(
+                        onPressed: state.isLoading
+                            ? null
+                            : () {
+                                final single =
+                                    state.lastResponse!.recommendations.first;
+                                // If current row incomplete, fill with word before confirming
+                                final isComplete = !state.grid.last.any(
+                                  (t) => t.letter.isEmpty,
+                                );
+                                if (!isComplete) {
+                                  controller.applyWordToCurrentRow(single.word);
+                                }
+                                controller.confirmWin(single.word);
+                              },
+                        icon: const Icon(Icons.check_circle),
+                        label: const Text('Confirm win'),
+                      ),
+                    ),
                   ElevatedButton.icon(
                     onPressed: state.isLoading ? null : controller.resetGame,
                     icon: const Icon(Icons.refresh),

--- a/lib/state/solver_state.dart
+++ b/lib/state/solver_state.dart
@@ -437,6 +437,35 @@ class SolverController extends StateNotifier<SolverUiState> {
     );
   }
 
+  // Validate that the current row's word is consistent with all previous
+  // feedback (history) and constraints. This does not mutate state or set
+  // loading flags. Returns false if the row is incomplete.
+  Future<bool> canConfirmWinWithCurrentRowWord() async {
+    if (state.grid.isEmpty || state.grid.last.isEmpty) return false;
+    final currentRow = state.grid.last;
+    final isComplete = !currentRow.any((t) => t.letter.isEmpty);
+    if (!isComplete) return false;
+    final guess = currentRow.map((t) => t.letter).join();
+
+    // Fast path: if we already have remaining candidates, check membership
+    final existingRemaining = state.lastResponse?.remainingWords;
+    if (existingRemaining != null && existingRemaining.isNotEmpty) {
+      return existingRemaining.contains(guess);
+    }
+
+    // Otherwise, compute candidates based on prior history only (exclude current row)
+    try {
+      final history = _toHistory();
+      final response = await repository.calculateNextMove(
+        config: state.config,
+        history: history,
+      );
+      return response.remainingWords.contains(guess);
+    } catch (_) {
+      return false;
+    }
+  }
+
   // Optional: explicit methods for docs behaviour
   void onTileTap(int index) => toggleFeedback(index);
   void onTileLongPress(int index) => toggleFeedback(index);

--- a/lib/state/solver_state.dart
+++ b/lib/state/solver_state.dart
@@ -377,16 +377,15 @@ class SolverController extends StateNotifier<SolverUiState> {
   }
 
   void resetGame() {
-    // New game resets everything, including prefix
+    // New game resets everything, including prefix; enforce defaults from Issue #14
     final newConfig = SolverConfig(
-      wordLength: state.config.wordLength,
+      wordLength: 5,
       prefix: null,
       dictionary: state.config.dictionary,
       autoCopyOnSelect: state.config.autoCopyOnSelect,
     );
-    final length = newConfig.wordLength;
     final newRow = List.generate(
-      length,
+      5,
       (_) => const SolverTile(letter: '', feedback: TileFeedback.black),
     );
     state = state.copyWith(
@@ -398,6 +397,35 @@ class SolverController extends StateNotifier<SolverUiState> {
       selectedIndex: 0,
       currentRowFeedbackTouched: false,
       pendingGreenLocks: null,
+    );
+  }
+
+  // Mark the current row as a confirmed win: set all tiles to green.
+  // If a single recommendation word is provided and the current row is incomplete,
+  // fill the row with that word before setting greens.
+  void confirmWin([String? word]) {
+    if (state.grid.isEmpty) return;
+    final rows = List<List<SolverTile>>.from(state.grid.map((r) => List.of(r)));
+    final currentRow = List<SolverTile>.from(rows.removeLast());
+
+    List<SolverTile> target = List<SolverTile>.from(currentRow);
+    // Optionally fill letters from provided word when length matches
+    if (word != null && word.length == target.length) {
+      for (int i = 0; i < target.length; i++) {
+        final ch = word[i].toLowerCase();
+        target[i] = target[i].copyWith(letter: ch);
+      }
+    }
+    // Set all feedback to green
+    for (int i = 0; i < target.length; i++) {
+      target[i] = target[i].copyWith(feedback: TileFeedback.green);
+    }
+
+    rows.add(target);
+    state = state.copyWith(
+      grid: rows,
+      selectedIndex: target.length - 1,
+      errorMessage: null,
     );
   }
 

--- a/lib/state/solver_state.dart
+++ b/lib/state/solver_state.dart
@@ -55,12 +55,16 @@ class SolverUiState {
     this.pendingGreenLocks,
   });
 
+  // Sentinels to allow explicitly setting nullable fields to null while
+  // preserving existing values when parameters are omitted.
+  static const Object _sentinel = Object();
+
   SolverUiState copyWith({
     SolverConfig? config,
     List<List<SolverTile>>? grid,
-    SolverResponse? lastResponse,
+    Object? lastResponse = _sentinel,
     bool? isLoading,
-    String? errorMessage,
+    Object? errorMessage = _sentinel,
     int? selectedIndex,
     bool? currentRowFeedbackTouched,
     Map<int, String>? pendingGreenLocks,
@@ -68,9 +72,13 @@ class SolverUiState {
     return SolverUiState(
       config: config ?? this.config,
       grid: grid ?? this.grid,
-      lastResponse: lastResponse ?? this.lastResponse,
+      lastResponse: identical(lastResponse, _sentinel)
+          ? this.lastResponse
+          : lastResponse as SolverResponse?,
       isLoading: isLoading ?? this.isLoading,
-      errorMessage: errorMessage,
+      errorMessage: identical(errorMessage, _sentinel)
+          ? this.errorMessage
+          : errorMessage as String?,
       selectedIndex: selectedIndex ?? this.selectedIndex,
       currentRowFeedbackTouched:
           currentRowFeedbackTouched ?? this.currentRowFeedbackTouched,


### PR DESCRIPTION
Implements Confirm Win and New Game logic as per Issue #14.

- Always-visible Confirm Win button, gated by row completeness and prior feedback consistency
- New Game resets to 5 letters, clears prefix, clears recommendations and filler query
- Preserves dictionary and auto-copy
- Keeps updated prefix behavior intact

Closes #14