### PR TITLE
feat(ui): Add Developer Profile Footer with optional LinkedIn web embed

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -9,6 +9,7 @@ import '../widgets/solver/recommendations_panel.dart';
 import '../widgets/solver/filler_results.dart';
 import '../state/filler_state.dart';
 import '../widgets/common/aurora.dart';
+import '../widgets/common/footer.dart';
 import '../widgets/common/bokeh_background.dart';
 
 class HomeScreen extends ConsumerWidget {
@@ -32,6 +33,7 @@ class HomeScreen extends ConsumerWidget {
               _GridSection(state: state, controller: controller),
               const SizedBox(height: 24),
               _RecommendationsSection(state: state, controller: controller),
+              const DeveloperFooter(),
             ],
           ),
         );

--- a/lib/widgets/common/footer.dart
+++ b/lib/widgets/common/footer.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import 'aurora.dart';
+import 'linkedin_embed_stub.dart'
+    if (dart.library.html) 'linkedin_embed_web.dart'
+    as embed;
+
+class DeveloperFooter extends StatelessWidget {
+  const DeveloperFooter({super.key});
+
+  static final Uri _profileUri = Uri.parse('https://www.linkedin.com/in/debro');
+
+  Future<void> _openProfile() async {
+    await launchUrl(_profileUri, mode: LaunchMode.externalApplication);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 16.0),
+      child: AuroraCard(
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final isNarrow = constraints.maxWidth < 520;
+            final content = _FooterContent(onTap: _openProfile);
+
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                if (kIsWeb) ...[
+                  // Web: optional embed loader with graceful fallback
+                  embed.LinkedInEmbedSection(
+                    fallback: content,
+                    profileUrl: _profileUri.toString(),
+                  ),
+                ] else ...[
+                  // Non-web platforms: simple, responsive fallback
+                  content,
+                ],
+                const SizedBox(height: 8),
+                if (!isNarrow)
+                  Text(
+                    'Connect with the developer',
+                    textAlign: TextAlign.center,
+                    style: Theme.of(
+                      context,
+                    ).textTheme.labelSmall?.copyWith(color: Colors.white70),
+                  ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _FooterContent extends StatelessWidget {
+  final VoidCallback onTap;
+  const _FooterContent({required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final isNarrow = constraints.maxWidth < 420;
+        final avatar = CircleAvatar(
+          radius: 20,
+          backgroundColor: const Color(0xFF2C2D34),
+          child: ClipOval(
+            child: Image.asset(
+              // Optional local fallback asset. If missing, the errorBuilder
+              // ensures an icon is shown instead.
+              'assets/avatar/debro.png',
+              width: 40,
+              height: 40,
+              fit: BoxFit.cover,
+              errorBuilder: (context, _, __) {
+                return const Icon(Icons.person, color: Colors.white70);
+              },
+            ),
+          ),
+        );
+
+        final linkText = Text(
+          'linkedin.com/in/debro',
+          style: Theme.of(
+            context,
+          ).textTheme.labelLarge?.copyWith(color: Colors.white),
+        );
+
+        final row = Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            avatar,
+            const SizedBox(width: 12),
+            Flexible(child: linkText),
+          ],
+        );
+
+        return Semantics(
+          label: 'Developer profile footer. Link to LinkedIn profile.',
+          button: true,
+          child: InkWell(
+            onTap: onTap,
+            child: isNarrow
+                ? Column(
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [row],
+                  )
+                : Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [row],
+                  ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/widgets/common/linkedin_embed_stub.dart
+++ b/lib/widgets/common/linkedin_embed_stub.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/widgets.dart';
+
+class LinkedInEmbedSection extends StatelessWidget {
+  final Widget fallback;
+  final String profileUrl;
+  const LinkedInEmbedSection({
+    super.key,
+    required this.fallback,
+    required this.profileUrl,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return fallback;
+  }
+}

--- a/lib/widgets/common/linkedin_embed_web.dart
+++ b/lib/widgets/common/linkedin_embed_web.dart
@@ -1,0 +1,103 @@
+// ignore_for_file: avoid_web_libraries_in_flutter, deprecated_member_use
+
+import 'dart:html' as html;
+import 'dart:ui' as ui;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+class LinkedInEmbedSection extends StatefulWidget {
+  final Widget fallback;
+  final String profileUrl;
+  const LinkedInEmbedSection({
+    super.key,
+    required this.fallback,
+    required this.profileUrl,
+  });
+
+  @override
+  State<LinkedInEmbedSection> createState() => _LinkedInEmbedSectionState();
+}
+
+class _LinkedInEmbedSectionState extends State<LinkedInEmbedSection> {
+  late final String _viewType = 'linkedin-embed-${identityHashCode(this)}';
+  html.DivElement? _container;
+  bool _loaded = false;
+
+  @override
+  void initState() {
+    super.initState();
+    // Register view factory once per instance
+    // ignore: undefined_prefixed_name
+    ui.platformViewRegistry.registerViewFactory(_viewType, (int viewId) {
+      _container = html.DivElement()
+        ..style.width = '100%'
+        ..style.display = 'flex'
+        ..style.justifyContent = 'center';
+      // Create badge container
+      final badge = html.DivElement()
+        ..classes.add('badge-base')
+        ..attributes['data-test-id'] = 'linkedin-badge'
+        ..attributes['data-locale'] = 'en_US'
+        ..attributes['data-size'] = 'medium'
+        ..attributes['data-theme'] = 'dark'
+        ..attributes['data-type'] = 'HORIZONTAL'
+        ..attributes['data-vanity'] = 'debro'
+        ..attributes['data-version'] = 'v1'
+        ..style.margin = '6px';
+      _container!.children.add(badge);
+
+      // Defer script load to avoid blocking FMP
+      Future.microtask(_ensureScriptLoaded)
+          .then((_) {
+            if (!mounted) return;
+            setState(() => _loaded = true);
+          })
+          .catchError((_) {
+            // Leave _loaded false; fallback will be shown
+          });
+      return _container!;
+    });
+  }
+
+  Future<void> _ensureScriptLoaded() async {
+    // Check if script already present
+    final scripts = html.document.querySelectorAll('script');
+    html.ScriptElement? existing;
+    for (final s in scripts.whereType<html.ScriptElement>()) {
+      if ((s.src).contains('platform.linkedin.com/in.js')) {
+        existing = s;
+        break;
+      }
+    }
+    if (existing == null) {
+      final script = html.ScriptElement()
+        ..type = 'text/javascript'
+        ..async = true
+        ..defer = true
+        ..src = 'https://platform.linkedin.com/in.js';
+      html.document.body?.append(script);
+      // Give the script a bit of time to process
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+    }
+
+    // Trigger plugin parse if available
+    final badgeScript =
+        html.document.createElement('script') as html.ScriptElement;
+    badgeScript.text = 'if(window.IN && IN.parse){IN.parse();}';
+    html.document.body?.append(badgeScript);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // If not loaded, show fallback; once loaded, show the embed
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (!_loaded) widget.fallback,
+        if (_loaded)
+          SizedBox(height: 88, child: HtmlElementView(viewType: _viewType)),
+      ],
+    );
+  }
+}

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,10 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -10,6 +10,7 @@ import cloud_functions
 import firebase_auth
 import firebase_core
 import firebase_storage
+import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseFirestorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseFirestorePlugin"))
@@ -17,4 +18,5 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FLTFirebaseStoragePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseStoragePlugin"))
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -381,6 +381,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "0aedad096a85b49df2e4725fa32118f9fa580f3b14af7a2d2221896a02cd5656"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.17"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "7f2022359d4c099eea7df3fdf739f7d3d3b9faf3166fb1dd390775176e0b76cb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.3"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: "4e9ba368772369e3e08f231d2301b4ef72b9ff87c31192ef471b380ef29a4935"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "17ba2000b847f334f16626a574c702b196723af2a289e7a93ffcb79acff855c2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "4bd2b7b4dc4d4d0b94e5babfffbca8eac1a126c7f3d6ecbc1a11013faa3abba2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "3284b6d2ac454cf34f114e1d3319866fdd1e19cdc329999057e44ffe936cfa77"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.4"
   vector_math:
     dependency: transitive
     description:
@@ -407,4 +471,4 @@ packages:
     version: "1.1.1"
 sdks:
   dart: ">=3.8.1 <4.0.0"
-  flutter: ">=3.22.0"
+  flutter: ">=3.27.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   firebase_storage: ^13.0.0
   flutter_riverpod: ^2.5.1
   characters: ^1.3.0
+  url_launcher: ^6.3.1
 
 dev_dependencies:
   flutter_test:
@@ -67,6 +68,8 @@ flutter:
   # Assets for word dictionaries
   assets:
     - assets/words/
+    # Optional local avatar for developer footer
+    - assets/avatar/
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/to/resolution-aware-images

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -10,6 +10,7 @@
 #include <firebase_auth/firebase_auth_plugin_c_api.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
 #include <firebase_storage/firebase_storage_plugin_c_api.h>
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   CloudFirestorePluginCApiRegisterWithRegistrar(
@@ -20,4 +21,6 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
   FirebaseStoragePluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FirebaseStoragePluginCApi"));
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -7,6 +7,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   firebase_auth
   firebase_core
   firebase_storage
+  url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
Implement issue #18: Developer Profile Footer added.

- Adds responsive footer widget with glass styling using Aurora components
- Opens external link to LinkedIn via url_launcher
- Web-only optional LinkedIn Member Profile Plugin embed with graceful fallback
- Defers script load and documents CSP considerations
- No layout regressions; footer is part of scrollable content below recommendations

Acceptance criteria addressed across web, iOS, Android, macOS, Windows, and Linux.

Notes:
- Optional local avatar path: assets/avatar/debro.png (fallback icon when absent)
- If using the LinkedIn plugin, script is injected lazily at runtime; if CSP blocks it, fallback UI shows.
