### PR TITLE
feat(solver): Gate submit + auto-load recommendations (app load, length change, green@0, New Game)

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -86,7 +86,23 @@ class HomeScreen extends ConsumerWidget {
                   controller.backspaceAtSelection();
                 } else if (key == LogicalKeyboardKey.enter ||
                     key == LogicalKeyboardKey.numpadEnter) {
-                  _gridSubmitWithFeedbackCheck(context, state, controller);
+                  // Gate submit: only when current row is complete
+                  final current = state.grid.isNotEmpty
+                      ? state.grid.last
+                      : const <SolverTile>[];
+                  final isComplete =
+                      current.isNotEmpty &&
+                      !current.any((t) => t.letter.isEmpty);
+                  if (isComplete) {
+                    _gridSubmitWithFeedbackCheck(context, state, controller);
+                  } else {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                        content: Text('Enter a complete word to submit'),
+                        duration: Duration(milliseconds: 1200),
+                      ),
+                    );
+                  }
                 }
               },
               child: Scaffold(
@@ -670,23 +686,39 @@ class _GridSectionState extends State<_GridSection> {
                     },
                   ),
                   const SizedBox(width: 8),
-                  ElevatedButton.icon(
-                    style: compactButtonStyle,
-                    onPressed: state.isLoading
-                        ? null
-                        : () => _gridSubmitWithFeedbackCheck(
-                            context,
-                            state,
-                            controller,
-                          ),
-                    icon: state.isLoading
-                        ? const SizedBox(
-                            width: 16,
-                            height: 16,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          )
-                        : Icon(Icons.send_rounded, size: isNarrow ? 18 : null),
-                    label: Text('Submit', style: labelTextStyle),
+                  Builder(
+                    builder: (context) {
+                      final current = state.grid.isNotEmpty
+                          ? state.grid.last
+                          : const <SolverTile>[];
+                      final canSubmit =
+                          !state.isLoading &&
+                          current.isNotEmpty &&
+                          !current.any((t) => t.letter.isEmpty);
+                      return ElevatedButton.icon(
+                        style: compactButtonStyle,
+                        onPressed: canSubmit
+                            ? () => _gridSubmitWithFeedbackCheck(
+                                context,
+                                state,
+                                controller,
+                              )
+                            : null,
+                        icon: state.isLoading
+                            ? const SizedBox(
+                                width: 16,
+                                height: 16,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                ),
+                              )
+                            : Icon(
+                                Icons.send_rounded,
+                                size: isNarrow ? 18 : null,
+                              ),
+                        label: Text('Submit', style: labelTextStyle),
+                      );
+                    },
                   ),
                 ],
               ),
@@ -758,6 +790,7 @@ class _RecommendationsSection extends StatelessWidget {
     return AuroraCard(
       child: RecommendationsPanel(
         response: state.lastResponse,
+        isLoading: state.isLoading,
         onSelectWord: (word) {
           controller.applyWordToCurrentRow(word);
           if (state.config.autoCopyOnSelect) {

--- a/lib/state/solver_state.dart
+++ b/lib/state/solver_state.dart
@@ -1,5 +1,6 @@
 // import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'dart:async';
 
 import '../models/solver_models.dart';
 import '../repositories/solver_repository.dart';
@@ -102,6 +103,7 @@ class SolverUiState {
 
 class SolverController extends StateNotifier<SolverUiState> {
   final SolverRepository repository;
+  Timer? _lengthChangeDebounce;
 
   SolverController({required this.repository})
     : super(
@@ -122,7 +124,27 @@ class SolverController extends StateNotifier<SolverUiState> {
           unlockPrefixThisRow: false,
           suppressCarryForwardOnce: false,
         ),
-      );
+      ) {
+    _scheduleInitialRecommendations();
+  }
+
+  // Kick off initial recommendations shortly after controller is created.
+  // This runs on app load to populate the recommendations panel automatically.
+  void _scheduleInitialRecommendations() {
+    // Use microtask to avoid synchronous state changes during provider build
+    Future.microtask(() {
+      if (!state.isLoading) {
+        // ignore: unawaited_futures
+        requestRecommendations();
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _lengthChangeDebounce?.cancel();
+    super.dispose();
+  }
 
   void setWordLength(int length) {
     final clamped = length < 3 ? 3 : (length > 20 ? 20 : length);
@@ -150,6 +172,15 @@ class SolverController extends StateNotifier<SolverUiState> {
       pendingGreenLocks: null,
       unlockPrefixThisRow: false,
     );
+
+    // Debounce recommendation recompute while sliding the length control
+    _lengthChangeDebounce?.cancel();
+    _lengthChangeDebounce = Timer(const Duration(milliseconds: 250), () {
+      if (!state.isLoading) {
+        // ignore: unawaited_futures
+        requestRecommendations();
+      }
+    });
   }
 
   // Note: color controls are not locked by prefix; only historical known greens enforce green
@@ -539,6 +570,13 @@ class SolverController extends StateNotifier<SolverUiState> {
       selectedIndex: colIndex,
       currentRowFeedbackTouched: true,
     );
+
+    // Trigger immediate recompute when the first tile turns green
+    if (colIndex == 0 && nextColor == TileFeedback.green && !state.isLoading) {
+      // Fire-and-forget; UI will reflect loading in panel
+      // ignore: unawaited_futures
+      requestRecommendations();
+    }
   }
 
   // Set feedback color on the most relevant tile for the user's current typing flow.
@@ -573,6 +611,12 @@ class SolverController extends StateNotifier<SolverUiState> {
     // Apply feedback without moving selection so typing continues to the next tile
     _updateTile(idx, feedback: nextColor);
     state = state.copyWith(currentRowFeedbackTouched: true);
+
+    // Trigger immediate recompute when the first tile turns green
+    if (idx == 0 && nextColor == TileFeedback.green && !state.isLoading) {
+      // ignore: unawaited_futures
+      requestRecommendations();
+    }
   }
 
   // Reset all feedback colors in the current input row to black while preserving letters.
@@ -657,6 +701,14 @@ class SolverController extends StateNotifier<SolverUiState> {
       // Ensure the next appended row (after first submission) does not carry forward prior greens
       suppressCarryForwardOnce: true,
     );
+
+    // After resetting to defaults, immediately load fresh recommendations
+    Future.microtask(() {
+      if (!state.isLoading) {
+        // ignore: unawaited_futures
+        requestRecommendations();
+      }
+    });
   }
 
   // Mark the current row as a confirmed win: set all tiles to green.

--- a/lib/widgets/solver/recommendations_panel.dart
+++ b/lib/widgets/solver/recommendations_panel.dart
@@ -6,11 +6,13 @@ import '../common/aurora.dart';
 class RecommendationsPanel extends StatelessWidget {
   final SolverResponse? response;
   final ValueChanged<String> onSelectWord;
+  final bool isLoading;
 
   const RecommendationsPanel({
     super.key,
     required this.response,
     required this.onSelectWord,
+    this.isLoading = false,
   });
 
   @override
@@ -26,7 +28,22 @@ class RecommendationsPanel extends StatelessWidget {
           textAlign: TextAlign.center,
         ),
         const SizedBox(height: 8),
-        if (response == null) ...[
+        if (isLoading) ...[
+          const SizedBox(height: 8),
+          const Center(
+            child: SizedBox(
+              width: 20,
+              height: 20,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Loading recommendations…',
+            style: theme.textTheme.bodySmall?.copyWith(color: Colors.white70),
+            textAlign: TextAlign.center,
+          ),
+        ] else if (response == null) ...[
           Text(
             'Tap Submit to get suggestions',
             style: theme.textTheme.bodySmall?.copyWith(color: Colors.white70),


### PR DESCRIPTION
Implement gating Submit until row complete, auto-load recommendations on app load, on length change (debounced), when first tile turns green, and after New Game reset.

- Gate Submit button and Enter key: enabled only when current row has no empty tiles.
- Recommendations now compute automatically:
  - On app load
  - On word length slider change (250ms debounce)
  - When first tile is set to green
  - When New Game is tapped (using default length)
- Recommendations panel shows loading state while computing.

Closes #46
