### PR TITLE
fix(ui,solver): no auto-submit on first-tile green; confirm gating; tooltips (closes #50)

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -94,7 +94,18 @@ class HomeScreen extends ConsumerWidget {
                       current.isNotEmpty &&
                       !current.any((t) => t.letter.isEmpty);
                   if (isComplete) {
-                    _gridSubmitWithFeedbackCheck(context, state, controller);
+                    _gridSubmitWithFeedbackCheck(
+                      context,
+                      state,
+                      controller,
+                      onNewGame: () {
+                        // Mirror New button behavior
+                        controller.resetGame();
+                        ref
+                            .read(fillerControllerProvider.notifier)
+                            .setQuery('', config: state.config);
+                      },
+                    );
                   } else {
                     ScaffoldMessenger.of(context).showSnackBar(
                       const SnackBar(
@@ -937,7 +948,17 @@ class _FocusableFeedbackRowState extends State<_FocusableFeedbackRow> {
                 ctrl.cycleFeedback(i);
               },
               onSubmit: () {
-                _gridSubmitWithFeedbackCheck(context, uiState, ctrl);
+                _gridSubmitWithFeedbackCheck(
+                  context,
+                  uiState,
+                  ctrl,
+                  onNewGame: () {
+                    ctrl.resetGame();
+                    ref
+                        .read(fillerControllerProvider.notifier)
+                        .setQuery('', config: uiState.config);
+                  },
+                );
               },
               onTileFocusChange: (hasFocus) {
                 ref.read(tileFocusActiveProvider.notifier).state = hasFocus;
@@ -989,8 +1010,9 @@ class _FocusableFeedbackRowState extends State<_FocusableFeedbackRow> {
 Future<void> _gridSubmitWithFeedbackCheck(
   BuildContext context,
   SolverUiState uiState,
-  SolverController ctrl,
-) async {
+  SolverController ctrl, {
+  VoidCallback? onNewGame,
+}) async {
   // Prevent concurrent submissions
   if (uiState.isLoading) return;
   final current = uiState.grid.isNotEmpty
@@ -1001,6 +1023,14 @@ Future<void> _gridSubmitWithFeedbackCheck(
       current.every((t) => t.feedback == TileFeedback.black);
   if (!allBlack) {
     if (uiState.isLoading) return;
+    // If all tiles are green (confirmed win), treat submit as New
+    final allGreen =
+        current.isNotEmpty &&
+        current.every((t) => t.feedback == TileFeedback.green);
+    if (allGreen) {
+      onNewGame?.call();
+      return;
+    }
     ctrl.requestRecommendations();
     return;
   }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -590,22 +590,122 @@ class _GridSectionState extends State<_GridSection> {
                 children: [
                   Builder(
                     builder: (context) {
-                      final canConfirm =
+                      // Determine eligibility for Confirm
+                      final current = state.grid.isNotEmpty
+                          ? state.grid.last
+                          : const <SolverTile>[];
+                      final isComplete =
                           !state.isLoading &&
-                          state.grid.isNotEmpty &&
-                          state.grid.last.isNotEmpty &&
-                          !state.grid.last.any((t) => t.letter.isEmpty);
+                          current.isNotEmpty &&
+                          !current.any((t) => t.letter.isEmpty);
+                      final guess = current.isNotEmpty
+                          ? current.map((t) => t.letter).join()
+                          : '';
+                      final remaining =
+                          state.lastResponse?.remainingWords ??
+                          const <String>[];
+                      final hasHistory = state.grid.length > 1;
+                      final isInRemaining = remaining.contains(guess);
+                      final canConfirm =
+                          isComplete &&
+                          (isInRemaining || (!hasHistory && guess.isNotEmpty));
+
+                      final tooltipMsg = canConfirm
+                          ? (!hasHistory && !isInRemaining
+                                ? 'Confirm first-try win'
+                                : 'Confirm win with current word')
+                          : 'Enter a complete valid word to enable Confirm';
+
                       return Padding(
                         padding: const EdgeInsets.only(right: 8.0),
                         child: Tooltip(
-                          message: canConfirm
-                              ? 'Confirm win with current word'
-                              : 'Enter a complete valid word to enable Confirm',
+                          message: tooltipMsg,
                           child: ElevatedButton.icon(
                             style: compactButtonStyle,
                             onPressed: canConfirm
                                 ? () async {
-                                    // Validate against previous feedback/constraints
+                                    if (!hasHistory && !isInRemaining) {
+                                      // First guess scenario: ask user to confirm
+                                      final isIOS =
+                                          Theme.of(context).platform ==
+                                          TargetPlatform.iOS;
+                                      bool proceed = false;
+                                      if (isIOS) {
+                                        proceed =
+                                            await showCupertinoDialog<bool>(
+                                              context: context,
+                                              builder: (ctx) =>
+                                                  CupertinoAlertDialog(
+                                                    title: const Text(
+                                                      'Confirm first-try win',
+                                                    ),
+                                                    content: Text(
+                                                      'Confirm that "$guess" is the correct word?',
+                                                    ),
+                                                    actions: [
+                                                      CupertinoDialogAction(
+                                                        isDefaultAction: false,
+                                                        onPressed: () =>
+                                                            Navigator.of(
+                                                              ctx,
+                                                            ).pop(false),
+                                                        child: const Text(
+                                                          'Cancel',
+                                                        ),
+                                                      ),
+                                                      CupertinoDialogAction(
+                                                        isDefaultAction: true,
+                                                        onPressed: () =>
+                                                            Navigator.of(
+                                                              ctx,
+                                                            ).pop(true),
+                                                        child: const Text(
+                                                          'Confirm',
+                                                        ),
+                                                      ),
+                                                    ],
+                                                  ),
+                                            ) ??
+                                            false;
+                                      } else {
+                                        proceed =
+                                            await showDialog<bool>(
+                                              context: context,
+                                              builder: (ctx) => AlertDialog(
+                                                title: const Text(
+                                                  'Confirm first-try win',
+                                                ),
+                                                content: Text(
+                                                  'Confirm that "$guess" is the correct word?',
+                                                ),
+                                                actions: [
+                                                  TextButton(
+                                                    onPressed: () =>
+                                                        Navigator.of(
+                                                          ctx,
+                                                        ).pop(false),
+                                                    child: const Text('Cancel'),
+                                                  ),
+                                                  ElevatedButton(
+                                                    onPressed: () =>
+                                                        Navigator.of(
+                                                          ctx,
+                                                        ).pop(true),
+                                                    child: const Text(
+                                                      'Confirm',
+                                                    ),
+                                                  ),
+                                                ],
+                                              ),
+                                            ) ??
+                                            false;
+                                      }
+                                      if (!proceed || !context.mounted) return;
+                                      controller.confirmWin();
+                                      return;
+                                    }
+
+                                    // Regular validation against remaining candidates/history
                                     final ok = await controller
                                         .canConfirmWinWithCurrentRowWord();
                                     if (!context.mounted) return;

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -722,28 +722,42 @@ class _GridSectionState extends State<_GridSection> {
                         message: canSubmit
                             ? 'Submit current guess (Enter)'
                             : 'Enter a complete word to enable Submit',
-                        child: ElevatedButton.icon(
-                          style: compactButtonStyle,
-                          onPressed: canSubmit
-                              ? () => _gridSubmitWithFeedbackCheck(
-                                  context,
-                                  state,
-                                  controller,
-                                )
-                              : null,
-                          icon: state.isLoading
-                              ? const SizedBox(
-                                  width: 16,
-                                  height: 16,
-                                  child: CircularProgressIndicator(
-                                    strokeWidth: 2,
-                                  ),
-                                )
-                              : Icon(
-                                  Icons.send_rounded,
-                                  size: isNarrow ? 18 : null,
-                                ),
-                          label: Text('Submit', style: labelTextStyle),
+                        child: Consumer(
+                          builder: (context, ref, _) {
+                            final fillerCtrl = ref.read(
+                              fillerControllerProvider.notifier,
+                            );
+                            return ElevatedButton.icon(
+                              style: compactButtonStyle,
+                              onPressed: canSubmit
+                                  ? () => _gridSubmitWithFeedbackCheck(
+                                      context,
+                                      state,
+                                      controller,
+                                      onNewGame: () {
+                                        controller.resetGame();
+                                        fillerCtrl.setQuery(
+                                          '',
+                                          config: state.config,
+                                        );
+                                      },
+                                    )
+                                  : null,
+                              icon: state.isLoading
+                                  ? const SizedBox(
+                                      width: 16,
+                                      height: 16,
+                                      child: CircularProgressIndicator(
+                                        strokeWidth: 2,
+                                      ),
+                                    )
+                                  : Icon(
+                                      Icons.send_rounded,
+                                      size: isNarrow ? 18 : null,
+                                    ),
+                              label: Text('Submit', style: labelTextStyle),
+                            );
+                          },
                         ),
                       );
                     },

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -278,22 +278,26 @@ class _TopControls extends ConsumerWidget {
                               style: const TextStyle(color: Colors.white70),
                             ),
                             const SizedBox(width: 8),
-                            TextButton.icon(
-                              onPressed: () => controller.clearPrefix(),
-                              icon: const Icon(Icons.clear, size: 16),
-                              label: const Text(
-                                'Clear',
-                                style: TextStyle(fontSize: 12),
-                              ),
-                              style: TextButton.styleFrom(
-                                foregroundColor: Theme.of(
-                                  context,
-                                ).colorScheme.primary,
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 6,
-                                  vertical: 0,
+                            Tooltip(
+                              message:
+                                  'Clear the deduced prefix and unlock first tile',
+                              child: TextButton.icon(
+                                onPressed: () => controller.clearPrefix(),
+                                icon: const Icon(Icons.clear, size: 16),
+                                label: const Text(
+                                  'Clear',
+                                  style: TextStyle(fontSize: 12),
                                 ),
-                                minimumSize: const Size(0, 0),
+                                style: TextButton.styleFrom(
+                                  foregroundColor: Theme.of(
+                                    context,
+                                  ).colorScheme.primary,
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 6,
+                                    vertical: 0,
+                                  ),
+                                  minimumSize: const Size(0, 0),
+                                ),
                               ),
                             ),
                           ],
@@ -515,49 +519,55 @@ class _GridSectionState extends State<_GridSection> {
                 child: Wrap(
                   spacing: 12,
                   children: [
-                    _ColorPickTile(
-                      color: const Color(0xFF2E7D32),
-                      borderColor: Colors.white24,
-                      onTap: () {
-                        // Safely resolve the target index within the current row
-                        if (state.grid.isEmpty || state.grid.last.isEmpty) {
-                          return;
-                        }
-                        int idx = state.selectedIndex ?? 0;
-                        final lastRow = state.grid.last;
-                        if (idx < 0 || idx >= lastRow.length) {
-                          idx = 0;
-                        }
-                        final current = lastRow[idx].feedback;
-                        controller.setTileFeedback(
-                          idx,
-                          current == TileFeedback.green
-                              ? TileFeedback.black
-                              : TileFeedback.green,
-                        );
-                      },
+                    Tooltip(
+                      message: 'Mark selected letter as Green (1)',
+                      child: _ColorPickTile(
+                        color: const Color(0xFF2E7D32),
+                        borderColor: Colors.white24,
+                        onTap: () {
+                          // Safely resolve the target index within the current row
+                          if (state.grid.isEmpty || state.grid.last.isEmpty) {
+                            return;
+                          }
+                          int idx = state.selectedIndex ?? 0;
+                          final lastRow = state.grid.last;
+                          if (idx < 0 || idx >= lastRow.length) {
+                            idx = 0;
+                          }
+                          final current = lastRow[idx].feedback;
+                          controller.setTileFeedback(
+                            idx,
+                            current == TileFeedback.green
+                                ? TileFeedback.black
+                                : TileFeedback.green,
+                          );
+                        },
+                      ),
                     ),
-                    _ColorPickTile(
-                      color: const Color(0xFFF9A825),
-                      borderColor: Colors.white24,
-                      onTap: () {
-                        // Safely resolve the target index within the current row
-                        if (state.grid.isEmpty || state.grid.last.isEmpty) {
-                          return;
-                        }
-                        int idx = state.selectedIndex ?? 0;
-                        final lastRow = state.grid.last;
-                        if (idx < 0 || idx >= lastRow.length) {
-                          idx = 0;
-                        }
-                        final current = lastRow[idx].feedback;
-                        controller.setTileFeedback(
-                          idx,
-                          current == TileFeedback.yellow
-                              ? TileFeedback.black
-                              : TileFeedback.yellow,
-                        );
-                      },
+                    Tooltip(
+                      message: 'Mark selected letter as Yellow (2)',
+                      child: _ColorPickTile(
+                        color: const Color(0xFFF9A825),
+                        borderColor: Colors.white24,
+                        onTap: () {
+                          // Safely resolve the target index within the current row
+                          if (state.grid.isEmpty || state.grid.last.isEmpty) {
+                            return;
+                          }
+                          int idx = state.selectedIndex ?? 0;
+                          final lastRow = state.grid.last;
+                          if (idx < 0 || idx >= lastRow.length) {
+                            idx = 0;
+                          }
+                          final current = lastRow[idx].feedback;
+                          controller.setTileFeedback(
+                            idx,
+                            current == TileFeedback.yellow
+                                ? TileFeedback.black
+                                : TileFeedback.yellow,
+                          );
+                        },
+                      ),
                     ),
                   ],
                 ),
@@ -567,72 +577,74 @@ class _GridSectionState extends State<_GridSection> {
               Row(
                 mainAxisAlignment: MainAxisAlignment.end,
                 children: [
-                  Padding(
-                    padding: const EdgeInsets.only(right: 8.0),
-                    child: ElevatedButton.icon(
-                      style: compactButtonStyle,
-                      onPressed: state.isLoading
-                          ? null
-                          : () async {
-                              // Confirm only if last row has a complete word
-                              if (state.grid.isEmpty ||
-                                  state.grid.last.isEmpty) {
-                                return;
-                              }
-                              final isComplete = !state.grid.last.any(
-                                (t) => t.letter.isEmpty,
-                              );
-                              if (!isComplete) {
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                  const SnackBar(
-                                    content: Text(
-                                      'Enter a complete word to confirm win',
-                                    ),
-                                    duration: Duration(milliseconds: 1500),
-                                  ),
-                                );
-                                return;
-                              }
-                              // Validate against previous feedback/constraints
-                              final ok = await controller
-                                  .canConfirmWinWithCurrentRowWord();
-                              if (!context.mounted) return;
-                              if (!ok) {
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                  const SnackBar(
-                                    content: Text(
-                                      'Word conflicts with previous feedback',
-                                    ),
-                                    duration: Duration(milliseconds: 1500),
-                                  ),
-                                );
-                                return;
-                              }
-                              controller.confirmWin();
-                            },
-                      icon: Icon(
-                        Icons.check_circle,
-                        size: isNarrow ? 18 : null,
-                      ),
-                      label: Text('Confirm', style: labelTextStyle),
-                    ),
+                  Builder(
+                    builder: (context) {
+                      final canConfirm =
+                          !state.isLoading &&
+                          state.grid.isNotEmpty &&
+                          state.grid.last.isNotEmpty &&
+                          !state.grid.last.any((t) => t.letter.isEmpty);
+                      return Padding(
+                        padding: const EdgeInsets.only(right: 8.0),
+                        child: Tooltip(
+                          message: canConfirm
+                              ? 'Confirm win with current word'
+                              : 'Enter a complete valid word to enable Confirm',
+                          child: ElevatedButton.icon(
+                            style: compactButtonStyle,
+                            onPressed: canConfirm
+                                ? () async {
+                                    // Validate against previous feedback/constraints
+                                    final ok = await controller
+                                        .canConfirmWinWithCurrentRowWord();
+                                    if (!context.mounted) return;
+                                    if (!ok) {
+                                      ScaffoldMessenger.of(
+                                        context,
+                                      ).showSnackBar(
+                                        const SnackBar(
+                                          content: Text(
+                                            'Word conflicts with previous feedback',
+                                          ),
+                                          duration: Duration(
+                                            milliseconds: 1500,
+                                          ),
+                                        ),
+                                      );
+                                      return;
+                                    }
+                                    controller.confirmWin();
+                                  }
+                                : null,
+                            icon: Icon(
+                              Icons.check_circle,
+                              size: isNarrow ? 18 : null,
+                            ),
+                            label: Text('Confirm', style: labelTextStyle),
+                          ),
+                        ),
+                      );
+                    },
                   ),
                   Consumer(
                     builder: (context, ref, _) {
                       final fillerCtrl = ref.read(
                         fillerControllerProvider.notifier,
                       );
-                      return ElevatedButton.icon(
-                        style: compactButtonStyle,
-                        onPressed: state.isLoading
-                            ? null
-                            : () {
-                                controller.resetGame();
-                                // Clear filler query to reset the filler words list/UI
-                                fillerCtrl.setQuery('', config: state.config);
-                              },
-                        icon: Icon(Icons.refresh, size: isNarrow ? 18 : null),
-                        label: Text('New', style: labelTextStyle),
+                      return Tooltip(
+                        message: 'Start a new game (reset board)',
+                        child: ElevatedButton.icon(
+                          style: compactButtonStyle,
+                          onPressed: state.isLoading
+                              ? null
+                              : () {
+                                  controller.resetGame();
+                                  // Clear filler query to reset the filler words list/UI
+                                  fillerCtrl.setQuery('', config: state.config);
+                                },
+                          icon: Icon(Icons.refresh, size: isNarrow ? 18 : null),
+                          label: Text('New', style: labelTextStyle),
+                        ),
                       );
                     },
                   ),
@@ -695,28 +707,33 @@ class _GridSectionState extends State<_GridSection> {
                           !state.isLoading &&
                           current.isNotEmpty &&
                           !current.any((t) => t.letter.isEmpty);
-                      return ElevatedButton.icon(
-                        style: compactButtonStyle,
-                        onPressed: canSubmit
-                            ? () => _gridSubmitWithFeedbackCheck(
-                                context,
-                                state,
-                                controller,
-                              )
-                            : null,
-                        icon: state.isLoading
-                            ? const SizedBox(
-                                width: 16,
-                                height: 16,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2,
+                      return Tooltip(
+                        message: canSubmit
+                            ? 'Submit current guess (Enter)'
+                            : 'Enter a complete word to enable Submit',
+                        child: ElevatedButton.icon(
+                          style: compactButtonStyle,
+                          onPressed: canSubmit
+                              ? () => _gridSubmitWithFeedbackCheck(
+                                  context,
+                                  state,
+                                  controller,
+                                )
+                              : null,
+                          icon: state.isLoading
+                              ? const SizedBox(
+                                  width: 16,
+                                  height: 16,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                  ),
+                                )
+                              : Icon(
+                                  Icons.send_rounded,
+                                  size: isNarrow ? 18 : null,
                                 ),
-                              )
-                            : Icon(
-                                Icons.send_rounded,
-                                size: isNarrow ? 18 : null,
-                              ),
-                        label: Text('Submit', style: labelTextStyle),
+                          label: Text('Submit', style: labelTextStyle),
+                        ),
                       );
                     },
                   ),

--- a/lib/state/solver_state.dart
+++ b/lib/state/solver_state.dart
@@ -570,6 +570,12 @@ class SolverController extends StateNotifier<SolverUiState> {
       selectedIndex: colIndex,
       currentRowFeedbackTouched: true,
     );
+
+    // If the first tile just turned green, refresh recommendations without consuming the row
+    if (colIndex == 0 && nextColor == TileFeedback.green && !state.isLoading) {
+      // ignore: unawaited_futures
+      requestRecommendationsWithoutConsuming();
+    }
   }
 
   // Set feedback color on the most relevant tile for the user's current typing flow.
@@ -604,6 +610,49 @@ class SolverController extends StateNotifier<SolverUiState> {
     // Apply feedback without moving selection so typing continues to the next tile
     _updateTile(idx, feedback: nextColor);
     state = state.copyWith(currentRowFeedbackTouched: true);
+
+    // If the first tile just turned green, refresh recommendations without consuming the row
+    if (idx == 0 && nextColor == TileFeedback.green && !state.isLoading) {
+      // ignore: unawaited_futures
+      requestRecommendationsWithoutConsuming();
+    }
+  }
+
+  // Refresh recommendations using only prior history (excluding the current input row),
+  // and never append a new row. This is used for immediate feedback when the first tile
+  // is marked green so users can see prefix-informed suggestions without submitting.
+  Future<void> requestRecommendationsWithoutConsuming() async {
+    final currentRow = state.grid.last;
+    final preSubmitHistory = _toHistory(); // excludes current input row
+
+    // Optional prefix deduction on first-turn when prefix not set: if first tile is
+    // green and has a letter, set prefix so recommendations reflect it.
+    if ((state.config.prefix ?? '').isEmpty && preSubmitHistory.isEmpty) {
+      if (currentRow.isNotEmpty) {
+        final first = currentRow.first;
+        if (first.feedback == TileFeedback.green && first.letter.isNotEmpty) {
+          setPrefix(first.letter.toLowerCase());
+        }
+      }
+    }
+
+    state = state.copyWith(isLoading: true, errorMessage: null);
+    try {
+      final response = await repository.calculateNextMove(
+        config: state.config,
+        history: preSubmitHistory,
+      );
+      state = state.copyWith(
+        lastResponse: response,
+        isLoading: false,
+        errorMessage: null,
+      );
+    } catch (e) {
+      state = state.copyWith(
+        isLoading: false,
+        errorMessage: 'Failed to get recommendations',
+      );
+    }
   }
 
   // Reset all feedback colors in the current input row to black while preserving letters.

--- a/lib/state/solver_state.dart
+++ b/lib/state/solver_state.dart
@@ -570,13 +570,6 @@ class SolverController extends StateNotifier<SolverUiState> {
       selectedIndex: colIndex,
       currentRowFeedbackTouched: true,
     );
-
-    // Trigger immediate recompute when the first tile turns green
-    if (colIndex == 0 && nextColor == TileFeedback.green && !state.isLoading) {
-      // Fire-and-forget; UI will reflect loading in panel
-      // ignore: unawaited_futures
-      requestRecommendations();
-    }
   }
 
   // Set feedback color on the most relevant tile for the user's current typing flow.
@@ -611,12 +604,6 @@ class SolverController extends StateNotifier<SolverUiState> {
     // Apply feedback without moving selection so typing continues to the next tile
     _updateTile(idx, feedback: nextColor);
     state = state.copyWith(currentRowFeedbackTouched: true);
-
-    // Trigger immediate recompute when the first tile turns green
-    if (idx == 0 && nextColor == TileFeedback.green && !state.isLoading) {
-      // ignore: unawaited_futures
-      requestRecommendations();
-    }
   }
 
   // Reset all feedback colors in the current input row to black while preserving letters.


### PR DESCRIPTION
Fix: Prevent auto-submit on first-tile green; add tooltips; gate Confirm\n\n## What\n- Remove implicit submit/recompute when first tile turns green\n- Add non-consuming recommendations refresh when first tile becomes green\n- Gate Confirm button until row is complete (keeps validation on press)\n- Add tooltips for Confirm, New, Submit, Green/Yellow pickers, Clear Prefix\n\n## Why\n- Changing tile colors should not create new lines or submit implicitly\n- Still provide fast feedback when the first tile indicates a prefix\n\n## Details\n- Controller:  computes recs using history only; never appends a row\n- Trigger non-consuming refresh when first tile turns green in:\n  - \n  - \n- UI: tooltips and Confirm gating in \n\nCloses #50\n