### PR TITLE
fix(solver): New button cancels stale async results and fully resets state (#17)

### DIFF
--- a/docs/issues/17-new-button-reset-stale-state.md
+++ b/docs/issues/17-new-button-reset-stale-state.md
@@ -1,0 +1,27 @@
+# Issue #17 — New game must cancel stale computations and clear memory
+
+## Summary
+Selecting a recommended word after pressing "New" sometimes fills tiles using feedback from a previous game. The root cause is an in-flight recommendation request finishing after the reset and writing its old `lastResponse` into the fresh state.
+
+## Expected
+- Pressing "New" fully resets board, history, and any background work so subsequent recommendations and selection-fill use only the new game state.
+
+## Actual
+- After pressing "New", a previous async compute can still complete and update `lastResponse`. This makes the UI show a correct recommendation list, but auto-fill uses mismatched history leading to incorrect letter locks.
+
+## Fix
+- Introduce a monotonically increasing request token in `SolverController`.
+- Increment the token on every new async recommendation request and on reset.
+- Only apply async results when their token matches the latest value.
+
+## Acceptance Criteria
+- After pressing "New", no prior game response can update state.
+- Selecting a word immediately after reset fills only according to the new board.
+- No regressions to slider length changes, dictionary changes, or filler actions.
+
+## Files Touched
+- `lib/state/solver_state.dart`: add `_requestToken`, guard both `requestRecommendations` and `requestRecommendationsWithoutConsuming`, bump token on `resetGame`.
+
+## Notes
+- This is a UI/logic-only change; no API changes.
+

--- a/lib/state/solver_state.dart
+++ b/lib/state/solver_state.dart
@@ -728,6 +728,8 @@ class SolverController extends StateNotifier<SolverUiState> {
   }
 
   void resetGame() {
+    // Immediately invalidate any in-flight computations from the previous game
+    _requestToken++;
     // New game resets everything, including prefix; enforce defaults from Issue #14
     final newConfig = SolverConfig(
       wordLength: 5,
@@ -756,8 +758,6 @@ class SolverController extends StateNotifier<SolverUiState> {
     // After resetting to defaults, immediately load fresh recommendations
     Future.microtask(() {
       if (!state.isLoading) {
-        // Invalidate any in-flight computations from the previous game
-        _requestToken++;
         // ignore: unawaited_futures
         requestRecommendations();
       }

--- a/lib/state/solver_state.dart
+++ b/lib/state/solver_state.dart
@@ -166,6 +166,8 @@ class SolverController extends StateNotifier<SolverUiState> {
       );
     }
     final newGrid = [newRow];
+    // Invalidate any in-flight computations tied to the previous board
+    _requestToken++;
     state = state.copyWith(
       config: state.config.copyWith(wordLength: clamped),
       grid: newGrid,
@@ -470,6 +472,8 @@ class SolverController extends StateNotifier<SolverUiState> {
       length,
       (_) => const SolverTile(letter: '', feedback: TileFeedback.black),
     );
+    // Invalidate any in-flight computations from prior dictionary/state
+    _requestToken++;
     state = state.copyWith(
       config: newConfig,
       grid: [newRow],

--- a/lib/state/solver_state.dart
+++ b/lib/state/solver_state.dart
@@ -104,6 +104,11 @@ class SolverUiState {
 class SolverController extends StateNotifier<SolverUiState> {
   final SolverRepository repository;
   Timer? _lengthChangeDebounce;
+  // Monotonic token to invalidate stale async computations. Any response
+  // from a request whose token is not the latest must be ignored. This fixes
+  // a race where pressing New while a previous compute is in-flight would
+  // allow the old response to overwrite the fresh reset state.
+  int _requestToken = 0;
 
   SolverController({required this.repository})
     : super(
@@ -622,6 +627,7 @@ class SolverController extends StateNotifier<SolverUiState> {
   // and never append a new row. This is used for immediate feedback when the first tile
   // is marked green so users can see prefix-informed suggestions without submitting.
   Future<void> requestRecommendationsWithoutConsuming() async {
+    final int tokenForThisCall = ++_requestToken;
     final currentRow = state.grid.last;
     final preSubmitHistory = _toHistory(); // excludes current input row
 
@@ -642,16 +648,21 @@ class SolverController extends StateNotifier<SolverUiState> {
         config: state.config,
         history: preSubmitHistory,
       );
-      state = state.copyWith(
-        lastResponse: response,
-        isLoading: false,
-        errorMessage: null,
-      );
+      // Ignore stale results if a newer request started after this one.
+      if (tokenForThisCall == _requestToken) {
+        state = state.copyWith(
+          lastResponse: response,
+          isLoading: false,
+          errorMessage: null,
+        );
+      }
     } catch (e) {
-      state = state.copyWith(
-        isLoading: false,
-        errorMessage: 'Failed to get recommendations',
-      );
+      if (tokenForThisCall == _requestToken) {
+        state = state.copyWith(
+          isLoading: false,
+          errorMessage: 'Failed to get recommendations',
+        );
+      }
     }
   }
 
@@ -741,6 +752,8 @@ class SolverController extends StateNotifier<SolverUiState> {
     // After resetting to defaults, immediately load fresh recommendations
     Future.microtask(() {
       if (!state.isLoading) {
+        // Invalidate any in-flight computations from the previous game
+        _requestToken++;
         // ignore: unawaited_futures
         requestRecommendations();
       }
@@ -848,6 +861,7 @@ class SolverController extends StateNotifier<SolverUiState> {
   }
 
   Future<void> requestRecommendations() async {
+    final int tokenForThisCall = ++_requestToken;
     final currentRow = state.grid.last;
     bool usedCurrentRowAsGuess = false;
 
@@ -940,27 +954,31 @@ class SolverController extends StateNotifier<SolverUiState> {
         updatedGrid = [...state.grid, newRow];
       }
 
-      state = state.copyWith(
-        lastResponse: response,
-        isLoading: false,
-        grid: updatedGrid,
-        errorMessage: null,
-        currentRowFeedbackTouched: false,
-        pendingGreenLocks: null,
-        // Once we move to the next step/row, relock prefix if present
-        unlockPrefixThisRow: false,
-        // If carry-forward was suppressed for this transition, clear the flag now
-        suppressCarryForwardOnce: state.suppressCarryForwardOnce
-            ? false
-            : state.suppressCarryForwardOnce,
-        // After consuming a row and appending a new one, start selection at first tile
-        selectedIndex: usedCurrentRowAsGuess ? 0 : state.selectedIndex,
-      );
+      if (tokenForThisCall == _requestToken) {
+        state = state.copyWith(
+          lastResponse: response,
+          isLoading: false,
+          grid: updatedGrid,
+          errorMessage: null,
+          currentRowFeedbackTouched: false,
+          pendingGreenLocks: null,
+          // Once we move to the next step/row, relock prefix if present
+          unlockPrefixThisRow: false,
+          // If carry-forward was suppressed for this transition, clear the flag now
+          suppressCarryForwardOnce: state.suppressCarryForwardOnce
+              ? false
+              : state.suppressCarryForwardOnce,
+          // After consuming a row and appending a new one, start selection at first tile
+          selectedIndex: usedCurrentRowAsGuess ? 0 : state.selectedIndex,
+        );
+      }
     } catch (e) {
-      state = state.copyWith(
-        isLoading: false,
-        errorMessage: 'Failed to get recommendations',
-      );
+      if (tokenForThisCall == _requestToken) {
+        state = state.copyWith(
+          isLoading: false,
+          errorMessage: 'Failed to get recommendations',
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
# Issue #17 — New game must cancel stale computations and clear memory

## Summary
Selecting a recommended word after pressing "New" sometimes fills tiles using feedback from a previous game. The root cause is an in-flight recommendation request finishing after the reset and writing its old `lastResponse` into the fresh state.

## Expected
- Pressing "New" fully resets board, history, and any background work so subsequent recommendations and selection-fill use only the new game state.

## Actual
- After pressing "New", a previous async compute can still complete and update `lastResponse`. This makes the UI show a correct recommendation list, but auto-fill uses mismatched history leading to incorrect letter locks.

## Fix
- Introduce a monotonically increasing request token in `SolverController`.
- Increment the token on every new async recommendation request and on reset.
- Only apply async results when their token matches the latest value.

## Acceptance Criteria
- After pressing "New", no prior game response can update state.
- Selecting a word immediately after reset fills only according to the new board.
- No regressions to slider length changes, dictionary changes, or filler actions.

## Files Touched
- `lib/state/solver_state.dart`: add `_requestToken`, guard both `requestRecommendations` and `requestRecommendationsWithoutConsuming`, bump token on `resetGame`.

## Notes
- This is a UI/logic-only change; no API changes.

