### PR TITLE
ci: Remove Android build from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,7 @@ jobs:
 
       - name: Build Flutter web (debug)
         run: flutter build web --debug
-
-      - name: Build Flutter Android APK (debug)
-        run: flutter build apk --debug
+      # Android build removed to speed up CI runs
 
   bash-scripts-check:
     name: Bash Scripts Check

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -11,7 +11,7 @@ This repository uses GitHub Actions for automated testing, building, and deploym
 - ✅ Flutter tests with coverage reporting
 - ✅ Python code linting and type checking
 - ✅ Security scanning
-- ✅ Build verification (web + Android debug)
+ - ✅ Build verification (web only)
 
 ### 2. **Deploy to Firebase Hosting** (`firebase-hosting-merge.yml`)
 **Triggers:** Push to `main` branch


### PR DESCRIPTION
Remove Android APK build step from CI to speed up runs. Updated docs to reflect web-only build verification.