### PR TITLE
feat(ui): Relocate length selector below grid, move Green/Black tggle inline, and soften bokeh (Closes #73)

### DIFF
--- a/docs/issues/2025-08-14-feedback-dialog-firestore-and-ip-rate-limiting.md
+++ b/docs/issues/2025-08-14-feedback-dialog-firestore-and-ip-rate-limiting.md
@@ -1,0 +1,44 @@
+# Feedback dialog (AppBar button) writing to Firestore with IP rate limiting
+
+## Overview
+
+Add a user-facing feedback dialog accessible from the AppBar (next to the Help button) that allows any user to submit general feedback and feature requests. Submissions are written to Firestore. Protect against spam by restricting submissions to at most one per IP address per hour.
+
+## Goals
+
+- Provide a clearly labeled Feedback button in the AppBar, next to the existing Help icon.
+- Show a modal dialog with a multiline text field and optional metadata (e.g., contact optional), and a Submit button.
+- On submit, write a document to Firestore under `feedback/appImprovements` (or a new `feedback/appFeedback`) with fields: `message`, `createdAt`, `clientIpHash` (or `ip` if stored via backend), and `appVersion` if available.
+- Enforce rate limit of one submission per IP per hour.
+
+## Context and References
+
+- AppBar and Help button: `lib/screens/home_screen.dart` → `_AppBarWithHelp`
+- Firestore rules: `firestore.rules` currently allow `create` under `feedback/**` for authenticated users.
+- Firebase project: `wordle-solver-kyle`
+
+## Requirements
+
+- UI
+  - Add a Feedback icon/button to the right of the Help icon in `_AppBarWithHelp`.
+  - Modal dialog with labeled textarea and character counter; disable submit when empty or over limit (e.g., 1–2k chars).
+- Data write
+  - Create document fields: `{ message: string, createdAt: serverTimestamp, platform: string, appVersion?: string }`.
+- Rate limiting
+  - Use a backend guard to enforce one-per-IP-per-hour. Options:
+    1) Cloud Function HTTP endpoint that forwards to Firestore with IP limit enforcement (preferred, avoids exposing IP from client).
+    2) Temporary client-side hash of public IP via a service and store hash; still needs backend validation for true enforcement.
+  - Implement solution (1) as part of this issue scope: a minimal Cloud Function endpoint that checks a TTL key (e.g., Firestore/RTDB doc or in-memory + Firestore) and rejects if within an hour.
+- Auth
+  - Allow anonymous auth; ensure client initializes Firebase before making the request.
+
+## Acceptance Criteria
+
+- Feedback button is visible next to Help in the AppBar on all platforms.
+- Submitting valid feedback creates a record in Firestore via the guarded endpoint; rejected within one hour if multiple attempts from same IP.
+- UI prevents empty submissions and provides success/error feedback.
+- Security rules remain satisfied; no sensitive data written by unauthenticated users beyond allowed feedback collection.
+
+## Notes
+
+- If deploying a function is out-of-scope for this sprint, implement the UI and wire it to a placeholder service; keep the IP-rate-limit guard behind a feature flag until the endpoint is live.

--- a/docs/issues/2025-08-14-mobile-ui-length-selector-and-bokeh-tuning.md
+++ b/docs/issues/2025-08-14-mobile-ui-length-selector-and-bokeh-tuning.md
@@ -1,0 +1,57 @@
+# Mobile UI – Move length selector below board, relocate Green/Black toggle, and tone down bokeh
+
+## Overview
+
+- On vertical mobile view, the word length selector grid is cramped in the top controls area.
+- The "Toggle all tiles Green/Black" control is currently in the top row, far from the color selector tiles directly under the board.
+- The bokeh background effect is visually heavy with too many orbs and an overly solid inner core.
+
+## Goals
+
+- Relocate the word length selector to its own dedicated section placed below the game board and above recommendations (mobile-first layout).
+- Move the "Toggle all tiles Green/Black" button to the right of the green/yellow color selector tiles under the board, with matching size and tap target.
+- Reduce the number and intensity of bokeh orbs and redesign the center to avoid a harsh solid circle, improving legibility.
+
+## Context and References
+
+- Length selector (current): `lib/screens/home_screen.dart` → `_TopControls` → `Wrap` of numeric tiles (see Text 'Length: ${state.config.wordLength}')
+- Board and color selector row: `lib/screens/home_screen.dart` → `_GridSection` → color selector `Wrap` (green/yellow tiles)
+- Toggle action: `lib/state/solver_state.dart` → `toggleAllGreenForCurrentRow()`
+- Toggle button location (current): `lib/screens/home_screen.dart` top settings row (near Auto-copy)
+- Bokeh background: `lib/widgets/common/bokeh_background.dart` (see `_generateOrbs` and `_BokehPainter.paint` inner circle pass)
+
+## Requirements
+
+- Length selector
+  - Create a new section widget (e.g., `LengthSelectorSection`) positioned between the grid and recommendations.
+  - On small widths, use a responsive `Wrap` or compact grid with adequate spacing and 40–44 logical px tap targets.
+  - Preserve existing behavior of `controller.setWordLength(len)` and resetting prefix; debounce recommendation recompute remains intact.
+- Toggle relocation
+  - Place the "Toggle all tiles Green/Black" control inline to the right of the color selector tiles under the board.
+  - Match the visual dimensions of the color tiles (icon size/padding) and include a tooltip.
+  - Action remains `controller.toggleAllGreenForCurrentRow()`.
+- Bokeh tuning
+  - Reduce orb count on small screens; lower alpha and/or radius slightly.
+  - Replace or soften the inner solid core: remove the hard inner circle or render a subtle radial falloff/ring with lower opacity.
+  - Maintain performance (animated builder + repaint boundary) while improving readability of foreground UI.
+
+## Acceptance Criteria
+
+- On a narrow/mobile viewport (portrait), the length selector is clearly spaced, fits without cramping, and has comfortable tap targets.
+- The all-green/black toggle appears next to the color tiles under the board, sized consistently, and behaves as before.
+- The background bokeh has fewer, softer orbs without a harsh solid inner core; foreground content becomes more legible.
+- Layout adapts across phone, tablet, and desktop using `LayoutBuilder`/`MediaQuery` and avoids hardcoded screen sizes.
+
+## Implementation Plan
+
+1) Extract length control from `_TopControls` into a new `LengthSelectorSection` and render it between `_GridSection` and `_RecommendationsSection`.
+2) Move the toggle button from the top settings row into the color selector row under the board; align icon and padding with color tiles.
+3) Update `BokehBackground`:
+   - `_generateOrbs`: lower `baseCount` on small `shortestSide`, slightly tweak radii/alpha.
+   - `_BokehPainter.paint`: remove or reduce the inner bright core; replace with softer radial falloff.
+4) Verify responsiveness with `LayoutBuilder` and spacing that scales on small widths.
+5) Add tests/Golden snapshots where feasible; manually verify mobile portrait on web and device/emulator.
+
+## Out of Scope
+
+- Solver logic, scoring, and recommendation algorithms remain unchanged.

--- a/docs/issues/2025-08-14-update-issue-16-dictionary-ingestion.md
+++ b/docs/issues/2025-08-14-update-issue-16-dictionary-ingestion.md
@@ -1,0 +1,47 @@
+# Update: Dictionary ingestion — Firestore first + scheduled publisher
+
+## Overview
+
+Change the ingestion flow so new words are written to Firestore first (after validation), then a scheduled job runs every 6 hours to merge approved submissions into the authoritative dictionary automatically.
+
+## New Requirements
+
+- Client submissions do not write directly to Cloud Storage.
+- New words must be validated before being accepted into Firestore:
+  - Correct length and charset
+  - Lowercase normalized
+  - Meets all existing solver validity criteria
+  - Consistent with all prior feedback constraints (greens/yellows/blacks) captured so far
+- A scheduled backend process runs every 6 hours to publish:
+  - Reads pending submissions from Firestore
+  - Performs a second validation pass (idempotent)
+  - Deduplicates and resolves conflicts
+  - Updates the source-of-truth dictionary
+  - Refreshes caches
+
+## Data Model (proposed)
+
+- Collection: `dictionary/submissions` (or `feedback/missingWords`)
+  - Fields: `{ word: string, language: string, submittedAt: timestamp, submitterId?: string, status: 'pending'|'approved'|'rejected', reason?: string }`
+- Collection (optional): `dictionary/published`
+  - Audit records for published batches
+
+## Scheduled Publisher (every 6 hours)
+
+- Name: `scheduledPublishDictionaries`
+- Steps:
+  1. Query `status == 'pending'`
+  2. Validate each word again (same rules as above)
+  3. Merge into dictionary (Storage or repo-backed source of truth)
+  4. Mark processed items as `approved` or `rejected` with `reason`
+  5. Update any in-memory/edge caches
+- Properties:
+  - Idempotent (safe to retry)
+  - Logs and metrics for visibility
+
+## Acceptance Criteria
+
+- New words are not written to Storage directly.
+- Only validated words make it into Firestore, and only approved words are published by the scheduled job.
+- Publisher runs every 6 hours and can be triggered manually for backfills.
+- Validation enforces length, charset, normalization, and compatibility with all prior feedback.

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -31,6 +31,8 @@ class HomeScreen extends ConsumerWidget {
               _TopControls(state: state, controller: controller),
               const SizedBox(height: 16),
               _GridSection(state: state, controller: controller),
+              const SizedBox(height: 16),
+              _LengthSelectorSection(state: state, controller: controller),
               const SizedBox(height: 24),
               _RecommendationsSection(state: state, controller: controller),
               const DeveloperFooter(),
@@ -251,80 +253,7 @@ class _TopControls extends ConsumerWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text(
-                      'Length: ${state.config.wordLength}',
-                      style: Theme.of(
-                        context,
-                      ).textTheme.labelMedium?.copyWith(color: Colors.white),
-                    ),
-                    const SizedBox(height: 8),
-                    LayoutBuilder(
-                      builder: (context, c) {
-                        // Responsive discrete selector: values 4..15 in a wrap/grid-like layout
-                        final values = List<int>.generate(12, (i) => 4 + i);
-                        final isNarrow = c.maxWidth < 480;
-                        final buttonStyle = FilledButton.styleFrom(
-                          padding: EdgeInsets.symmetric(
-                            horizontal: isNarrow ? 8 : 10,
-                            vertical: isNarrow ? 8 : 10,
-                          ),
-                          visualDensity: isNarrow
-                              ? const VisualDensity(
-                                  horizontal: -2,
-                                  vertical: -2,
-                                )
-                              : VisualDensity.compact,
-                          minimumSize: const Size(0, 0),
-                        );
-                        return Wrap(
-                          spacing: 6,
-                          runSpacing: 6,
-                          children: [
-                            for (final len in values)
-                              Builder(
-                                builder: (context) {
-                                  final bool selected =
-                                      len == state.config.wordLength;
-                                  final Widget inner = Text(
-                                    '$len',
-                                    style: TextStyle(
-                                      fontWeight: selected
-                                          ? FontWeight.w700
-                                          : FontWeight.w500,
-                                      color: Colors.white,
-                                    ),
-                                  );
-                                  void onPressed() {
-                                    controller.setWordLength(len);
-                                    final newConfig = state.config.copyWith(
-                                      wordLength: len,
-                                      prefix: null,
-                                    );
-                                    fillerCtrl.setQuery('', config: newConfig);
-                                  }
-
-                                  return SizedBox(
-                                    width: isNarrow
-                                        ? (c.maxWidth - 6 * 3) / 4
-                                        : null,
-                                    child: selected
-                                        ? FilledButton(
-                                            style: buttonStyle,
-                                            onPressed: onPressed,
-                                            child: inner,
-                                          )
-                                        : FilledButton.tonal(
-                                            style: buttonStyle,
-                                            onPressed: onPressed,
-                                            child: inner,
-                                          ),
-                                  );
-                                },
-                              ),
-                          ],
-                        );
-                      },
-                    ),
+                    // Length selector moved below the board (see _LengthSelectorSection)
                   ],
                 ),
               ),
@@ -409,14 +338,7 @@ class _TopControls extends ConsumerWidget {
                 ],
               ),
               const SizedBox(width: 8),
-              Tooltip(
-                message:
-                    'Toggle all tiles in the current word between Green and Black',
-                child: IconButton(
-                  icon: const Icon(Icons.task_alt_rounded),
-                  onPressed: () => controller.toggleAllGreenForCurrentRow(),
-                ),
-              ),
+              // Toggle all tiles control moved next to color selector under the board
             ],
           ),
           const SizedBox(height: 12),
@@ -603,6 +525,37 @@ class _GridSectionState extends State<_GridSection> {
                                 : TileFeedback.yellow,
                           );
                         },
+                      ),
+                    ),
+                    Tooltip(
+                      message:
+                          'Toggle all tiles in the current word between Green and Black',
+                      child: SizedBox(
+                        width: 44,
+                        height: 44,
+                        child: Material(
+                          color: Colors.transparent,
+                          child: InkWell(
+                            borderRadius: BorderRadius.circular(12),
+                            onTap: () =>
+                                controller.toggleAllGreenForCurrentRow(),
+                            child: Container(
+                              decoration: BoxDecoration(
+                                borderRadius: BorderRadius.circular(12),
+                                border: Border.all(
+                                  color: Colors.white24,
+                                  width: 1.5,
+                                ),
+                              ),
+                              alignment: Alignment.center,
+                              child: const Icon(
+                                Icons.task_alt_rounded,
+                                color: Colors.white,
+                                size: 22,
+                              ),
+                            ),
+                          ),
+                        ),
                       ),
                     ),
                   ],
@@ -1018,6 +971,95 @@ class _RecommendationsSection extends ConsumerWidget {
             );
           }
         },
+      ),
+    );
+  }
+}
+
+class _LengthSelectorSection extends ConsumerWidget {
+  final SolverUiState state;
+  final SolverController controller;
+
+  const _LengthSelectorSection({required this.state, required this.controller});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final fillerCtrl = ref.read(fillerControllerProvider.notifier);
+    return AuroraCard(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 6.0),
+        child: LayoutBuilder(
+          builder: (context, c) {
+            final values = List<int>.generate(12, (i) => 4 + i);
+            final isNarrow = c.maxWidth < 480;
+            final buttonStyle = FilledButton.styleFrom(
+              padding: EdgeInsets.symmetric(
+                horizontal: isNarrow ? 8 : 10,
+                vertical: isNarrow ? 8 : 10,
+              ),
+              visualDensity: isNarrow
+                  ? const VisualDensity(horizontal: -2, vertical: -2)
+                  : VisualDensity.compact,
+              minimumSize: const Size(0, 0),
+            );
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Length: ${state.config.wordLength}',
+                  style: Theme.of(
+                    context,
+                  ).textTheme.labelMedium?.copyWith(color: Colors.white),
+                ),
+                const SizedBox(height: 8),
+                Wrap(
+                  spacing: 6,
+                  runSpacing: 6,
+                  children: [
+                    for (final len in values)
+                      Builder(
+                        builder: (context) {
+                          final bool selected = len == state.config.wordLength;
+                          final inner = Text(
+                            '$len',
+                            style: TextStyle(
+                              fontWeight: selected
+                                  ? FontWeight.w700
+                                  : FontWeight.w500,
+                              color: Colors.white,
+                            ),
+                          );
+                          void onPressed() {
+                            controller.setWordLength(len);
+                            final newConfig = state.config.copyWith(
+                              wordLength: len,
+                              prefix: null,
+                            );
+                            fillerCtrl.setQuery('', config: newConfig);
+                          }
+
+                          return SizedBox(
+                            width: isNarrow ? (c.maxWidth - 6 * 3) / 4 : null,
+                            child: selected
+                                ? FilledButton(
+                                    style: buttonStyle,
+                                    onPressed: onPressed,
+                                    child: inner,
+                                  )
+                                : FilledButton.tonal(
+                                    style: buttonStyle,
+                                    onPressed: onPressed,
+                                    child: inner,
+                                  ),
+                          );
+                        },
+                      ),
+                  ],
+                ),
+              ],
+            );
+          },
+        ),
       ),
     );
   }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -992,13 +992,15 @@ class _LengthSelectorSection extends ConsumerWidget {
               minimumSize: const Size(0, 0),
             );
             // Compute responsive columns so options wrap neatly on any width
-            const double _spacing = 6.0;
-            final double _minTileWidth = isNarrow ? 44.0 : 48.0;
-            final int _columns = (c.maxWidth / (_minTileWidth + _spacing))
-                .floor()
-                .clamp(2, 8);
-            final double _tileWidth =
-                (c.maxWidth - _spacing * (_columns - 1)) / _columns;
+            const double spacingValue = 6.0;
+            final double minTileWidth = isNarrow ? 44.0 : 48.0;
+            final int columnsCount =
+                (c.maxWidth / (minTileWidth + spacingValue)).floor().clamp(
+                  2,
+                  8,
+                );
+            final double tileWidth =
+                (c.maxWidth - spacingValue * (columnsCount - 1)) / columnsCount;
 
             return Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -1011,8 +1013,8 @@ class _LengthSelectorSection extends ConsumerWidget {
                 ),
                 const SizedBox(height: 8),
                 Wrap(
-                  spacing: _spacing,
-                  runSpacing: _spacing,
+                  spacing: spacingValue,
+                  runSpacing: spacingValue,
                   children: [
                     for (final len in values)
                       Builder(
@@ -1037,7 +1039,7 @@ class _LengthSelectorSection extends ConsumerWidget {
                           }
 
                           return SizedBox(
-                            width: _tileWidth,
+                            width: tileWidth,
                             child: selected
                                 ? FilledButton(
                                     style: buttonStyle,

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -249,17 +249,6 @@ class _TopControls extends ConsumerWidget {
         children: [
           Row(
             children: [
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    // Length selector moved below the board (see _LengthSelectorSection)
-                  ],
-                ),
-              ),
-              const SizedBox(width: 12),
-              // Prefix chip removed; prefix control is now an action button below the board
-              const SizedBox(width: 12),
               Flexible(
                 flex: 1,
                 child: DropdownButtonFormField<String>(
@@ -1002,6 +991,15 @@ class _LengthSelectorSection extends ConsumerWidget {
                   : VisualDensity.compact,
               minimumSize: const Size(0, 0),
             );
+            // Compute responsive columns so options wrap neatly on any width
+            const double _spacing = 6.0;
+            final double _minTileWidth = isNarrow ? 44.0 : 48.0;
+            final int _columns = (c.maxWidth / (_minTileWidth + _spacing))
+                .floor()
+                .clamp(2, 8);
+            final double _tileWidth =
+                (c.maxWidth - _spacing * (_columns - 1)) / _columns;
+
             return Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -1013,8 +1011,8 @@ class _LengthSelectorSection extends ConsumerWidget {
                 ),
                 const SizedBox(height: 8),
                 Wrap(
-                  spacing: 6,
-                  runSpacing: 6,
+                  spacing: _spacing,
+                  runSpacing: _spacing,
                   children: [
                     for (final len in values)
                       Builder(
@@ -1039,7 +1037,7 @@ class _LengthSelectorSection extends ConsumerWidget {
                           }
 
                           return SizedBox(
-                            width: isNarrow ? (c.maxWidth - 6 * 3) / 4 : null,
+                            width: _tileWidth,
                             child: selected
                                 ? FilledButton(
                                     style: buttonStyle,

--- a/lib/widgets/common/bokeh_background.dart
+++ b/lib/widgets/common/bokeh_background.dart
@@ -75,10 +75,10 @@ class _BokehBackgroundState extends State<BokehBackground>
     final rand = math.Random(42);
     final colors = kAuroraGradient.colors;
 
-    // Adapt orb count to size (increase for stronger visibility)
+    // Adapt orb count to size with a lighter default for all platforms
     final baseCount = size.shortestSide < 500
-        ? 10
-        : (size.shortestSide < 900 ? 14 : 18);
+        ? 6
+        : (size.shortestSide < 900 ? 10 : 12);
 
     // Use a jittered grid layout to avoid visible clustering
     final cols = (math.sqrt(baseCount)).ceil();
@@ -101,11 +101,11 @@ class _BokehBackgroundState extends State<BokehBackground>
 
       final color = colors[i % colors.length];
       final radius = lerpDouble(
-        60,
-        size.shortestSide * 0.22,
+        48,
+        size.shortestSide * 0.18,
         rand.nextDouble(),
       )!;
-      final alpha = lerpDouble(0.16, 0.28, rand.nextDouble())!;
+      final alpha = lerpDouble(0.10, 0.20, rand.nextDouble())!;
 
       // Seamless periodic motion parameters (integer frequencies)
       final freqX = 1 + rand.nextInt(3); // 1..3
@@ -152,20 +152,22 @@ class _BokehPainter extends CustomPainter {
     canvas.drawRect(Offset.zero & size, bgPaint);
 
     final outerPaint = Paint()
-      ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 18);
-    final innerPaint = Paint()
-      ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 6);
+      ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 16);
+    final ringPaint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2.0
+      ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 4);
 
     for (final orb in orbs) {
       final pos = orb.positionAt(time);
-      // Outer soft glow
+      // Outer soft glow (softer than before)
       outerPaint.color = orb.color;
       canvas.drawCircle(pos, orb.radius, outerPaint);
-      // Inner brighter core to make the bokeh stand out in screenshots
-      innerPaint.color = orb.color.withValues(
-        alpha: (orb.alpha + 0.22).clamp(0.0, 0.6),
+      // Subtle ring to add structure without a harsh solid core
+      ringPaint.color = orb.color.withValues(
+        alpha: (orb.alpha * 0.6).clamp(0.0, 0.24),
       );
-      canvas.drawCircle(pos, orb.radius * 0.45, innerPaint);
+      canvas.drawCircle(pos, orb.radius * 0.52, ringPaint);
     }
   }
 


### PR DESCRIPTION
# Mobile UI – Move length selector below board, relocate Green/Black toggle, and tone down bokeh

## Overview

- On vertical mobile view, the word length selector grid is cramped in the top controls area.
- The "Toggle all tiles Green/Black" control is currently in the top row, far from the color selector tiles directly under the board.
- The bokeh background effect is visually heavy with too many orbs and an overly solid inner core.

## Goals

- Relocate the word length selector to its own dedicated section placed below the game board and above recommendations (mobile-first layout).
- Move the "Toggle all tiles Green/Black" button to the right of the green/yellow color selector tiles under the board, with matching size and tap target.
- Reduce the number and intensity of bokeh orbs and redesign the center to avoid a harsh solid circle, improving legibility.

## Context and References

- Length selector (current): `lib/screens/home_screen.dart` → `_TopControls` → `Wrap` of numeric tiles (see Text 'Length: ${state.config.wordLength}')
- Board and color selector row: `lib/screens/home_screen.dart` → `_GridSection` → color selector `Wrap` (green/yellow tiles)
- Toggle action: `lib/state/solver_state.dart` → `toggleAllGreenForCurrentRow()`
- Toggle button location (current): `lib/screens/home_screen.dart` top settings row (near Auto-copy)
- Bokeh background: `lib/widgets/common/bokeh_background.dart` (see `_generateOrbs` and `_BokehPainter.paint` inner circle pass)

## Requirements

- Length selector
  - Create a new section widget (e.g., `LengthSelectorSection`) positioned between the grid and recommendations.
  - On small widths, use a responsive `Wrap` or compact grid with adequate spacing and 40–44 logical px tap targets.
  - Preserve existing behavior of `controller.setWordLength(len)` and resetting prefix; debounce recommendation recompute remains intact.
- Toggle relocation
  - Place the "Toggle all tiles Green/Black" control inline to the right of the color selector tiles under the board.
  - Match the visual dimensions of the color tiles (icon size/padding) and include a tooltip.
  - Action remains `controller.toggleAllGreenForCurrentRow()`.
- Bokeh tuning
  - Reduce orb count on small screens; lower alpha and/or radius slightly.
  - Replace or soften the inner solid core: remove the hard inner circle or render a subtle radial falloff/ring with lower opacity.
  - Maintain performance (animated builder + repaint boundary) while improving readability of foreground UI.

## Acceptance Criteria

- On a narrow/mobile viewport (portrait), the length selector is clearly spaced, fits without cramping, and has comfortable tap targets.
- The all-green/black toggle appears next to the color tiles under the board, sized consistently, and behaves as before.
- The background bokeh has fewer, softer orbs without a harsh solid inner core; foreground content becomes more legible.
- Layout adapts across phone, tablet, and desktop using `LayoutBuilder`/`MediaQuery` and avoids hardcoded screen sizes.

## Implementation Plan

1) Extract length control from `_TopControls` into a new `LengthSelectorSection` and render it between `_GridSection` and `_RecommendationsSection`.
2) Move the toggle button from the top settings row into the color selector row under the board; align icon and padding with color tiles.
3) Update `BokehBackground`:
   - `_generateOrbs`: lower `baseCount` on small `shortestSide`, slightly tweak radii/alpha.
   - `_BokehPainter.paint`: remove or reduce the inner bright core; replace with softer radial falloff.
4) Verify responsiveness with `LayoutBuilder` and spacing that scales on small widths.
5) Add tests/Golden snapshots where feasible; manually verify mobile portrait on web and device/emulator.

## Out of Scope

- Solver logic, scoring, and recommendation algorithms remain unchanged.
